### PR TITLE
Fix unexpected keyword argument error

### DIFF
--- a/flask_rabbitmq/RabbitMQ.py
+++ b/flask_rabbitmq/RabbitMQ.py
@@ -95,8 +95,8 @@ class RabbitMQ(object):
 
     def basic_consuming(self, queue_name, callback):
         self._channel.basic_consume(
-            consumer_callback=callback,
-            queue=queue_name
+            queue_name,
+            callback
         )
 
     def consuming(self):


### PR DESCRIPTION
This fixes the unexpected keyword argument 'consumer_callback' on the basic_consuming method due to an update in the pika library